### PR TITLE
Adding Features and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,94 @@
+# ldapcheck
+
+A lightweight LDAP signing and channel binding enumeration and testing tool designed for Active Directory environments. 
+
+## Features
+
+- Domain Controller discovery via DNS
+- NTLM authentication support
+- Support for both password and hash-based authentication (Pass-the-Hash)
+- Configurable connection timeouts
+- Multiple output formats for discovered DCs and relay targets
+- File-based target input support
+
+## Installation
+
+```bash
+go install github.com/DriftSec/ldapcheck@latest
+```
+
+Or build from source:
+
+```bash
+git clone https://github.com/DriftSec/ldapcheck.git
+cd ldapcheck
+go build
+```
+
+## Usage
+
+Basic usage examples:
+
+```bash
+# Test single target with username/password
+ldapcheck -t dc.domain.com -u user@domain.com -p password
+
+# Test single target with NTLM hash
+ldapcheck -t dc.domain.com -u user@domain.com -H <NTLM_HASH>
+
+# Discover DCs for a domain
+ldapcheck -T domain.com
+
+# Test multiple targets from a file
+ldapcheck -t targets.txt -u user@domain.com -p password
+```
+
+### Command Line Options
+
+```
+ldapcheck -h
+
+  -H string
+        user NTLM hash
+  -T string
+        Query this domain for LDAP targets
+  -dc-out string
+        output file for discovered DCs (one per line)
+  -p string
+        user password
+  -relay-out string
+        output file for relay targets (format: ldap[s]://host)
+  -t string
+        target address or file containing targets
+  -timeout duration
+        timeout for LDAP connections (default 5s)
+  -u string
+        username, formats: user@domain or domain\user
+```
+
+## Output Formats
+
+### DC List Output (-dc-out)
+
+The `-dc-out` option generates a list of discovered Domain Controllers. Each line in the output file represents a single DC.
+
+Example output:
+
+```
+dc1.domain.com
+dc1.domain.com
+dc2.domain.com
+dc2.domain.com
+```
+
+### Relay List Output (-relay-out)
+
+The `-relay-out` option generates a list of relay targets. Each line in the output file represents a single relay target for use with ntlmrelayx.py
+
+Example output:
+
+```
+ldap://dc1.domain.com
+ldaps://dc1.domain.com
+ldap://dc2.domain.com
+```

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ var (
 	relayFile string
 	dcFile    string
 	relayLst  []string
+	dcLst     []string
 	timeout   time.Duration
 )
 

--- a/main.go
+++ b/main.go
@@ -118,7 +118,11 @@ func main() {
 			ldapURL := fmt.Sprintf("ldap://%s:389", target)
 			l, err := ldap.DialURL(ldapURL, dialOpts...)
 			if err != nil {
-				log.Printf("[ERROR] Failed to connect to %s: %v", target, err)
+				if strings.Contains(err.Error(), "i/o timeout") {
+					fmt.Printf("\tUnable to connect to LDAP (389): Connection timed out\n")
+				} else {
+					log.Printf("[ERROR] Failed to connect to %s: %v", target, err)
+				}
 				continue
 			}
 			defer l.Close()
@@ -146,7 +150,11 @@ func main() {
 		ldapsURL := fmt.Sprintf("ldaps://%s:636", target)
 		ls, err := ldap.DialURL(ldapsURL, dialOpts...)
 		if err != nil {
-			log.Printf("[ERROR] Failed to connect to %s: %v", target, err)
+			if strings.Contains(err.Error(), "i/o timeout") {
+				fmt.Printf("\tUnable to connect to LDAPS (636): Connection timed out\n")
+			} else {
+				log.Printf("[ERROR] Failed to connect to %s: %v", target, err)
+			}
 			continue
 		}
 		defer ls.Close()

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"crypto/tls"
 	"errors"
 	"flag"
 	"fmt"
@@ -107,6 +108,7 @@ func main() {
 	// For LDAP connections
 	dialOpts := []ldap.DialOpt{
 		ldap.DialWithDialer(&net.Dialer{Timeout: timeout}),
+		ldap.DialWithTLSConfig(&tls.Config{InsecureSkipVerify: true}),
 	}
 
 	for _, target := range targets {


### PR DESCRIPTION
Added:

* `-dc-out` and `-relay-out` flags. Let you decide if you want a list of targets for ntlmrelayx or just a list of DCs that are reachable.
* A timeout flag to prevent one-minute stalls for non-reachable DCs
* Cleaned up timeout flags
* README with install instructions and other details. 